### PR TITLE
fix Br template translateRawData to match declaration

### DIFF
--- a/Templates/Br.php
+++ b/Templates/Br.php
@@ -77,7 +77,7 @@ class Br extends Regex
     protected $available = '/(No match for domain|release process: reserved)/i';
 
 
-    public function translateRawData($rawdata)
+    public function translateRawData($rawdata, $config)
     {
         return utf8_encode($rawdata);
     }


### PR DESCRIPTION
Fatal error: Declaration of WhoisParser\Templates\Br::translateRawData($rawdata) must be compatible with WhoisParser\Templates\Type\AbstractTemplate::translateRawData($rawdata, $config) in whoisparser/Templates/Br.php on line 80